### PR TITLE
mongo: fix deadlock

### DIFF
--- a/mongo/votes.go
+++ b/mongo/votes.go
@@ -52,8 +52,6 @@ func (ms *MongoStorage) IncreaseVoteCount(userFID uint64, electionID types.HexBy
 }
 
 func (ms *MongoStorage) addVoterToElection(electionID types.HexBytes, userFID uint64) error {
-	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
addVoterToElection() is called on IncreaseVoteCount() which already takes the lock.