### PR TITLE
feature: remaining voters endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -562,6 +562,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err := uAPI.Endpoint.RegisterMethod("/remainingVotersOf/{electionID}", http.MethodGet, "public", handler.remainingVotersForElection); err != nil {
+		log.Fatal(err)
+	}
+
 	if err := uAPI.Endpoint.RegisterMethod("/preview/{electionID}", http.MethodGet, "public", handler.preview); err != nil {
 		log.Fatal(err)
 	}

--- a/types.go
+++ b/types.go
@@ -128,6 +128,5 @@ type CommunityList struct {
 // ElectionVotersUsernames defines the usernames of the voters and the remaining
 // users to vote in an election
 type ElectionVotersUsernames struct {
-	Voters    []string `json:"voters"`
-	Remaining []string `json:"remaining"`
+	Usernames []string `json:"usernames"`
 }

--- a/types.go
+++ b/types.go
@@ -124,3 +124,10 @@ type Community struct {
 type CommunityList struct {
 	Communities []*Community `json:"communities"`
 }
+
+// ElectionVotersUsernames defines the usernames of the voters and the remaining
+// users to vote in an election
+type ElectionVotersUsernames struct {
+	Voters    []string `json:"voters"`
+	Remaining []string `json:"remaining"`
+}


### PR DESCRIPTION
Including remaining users to vote in voters of API call. Now the endpoint: `GET /votersOf/{electionId}` returns the voters under `usernames` array:
```json
{
  "usernames": [
    "kacuatro.eth"
  ]
}
```

And now, there is a new endpoint that returns the list of users in the census that have not voted yet: `GET /remainingVotersOf/{electionID}`
```json
{
  "usernames": [
    "okay3637",
    "drsrangerz",
    "ridgeway",
    "qris",
    "hardiata",
    "youngboytroppers",
    "victoctero",
    "mahmood9494",
    "ivokub",
    "safiraulia",
    "omer",
    "mraz125.eth",
    "devadev",
    "ariadababy.eth",
    "tos",
    "vali-caster",
    "vocdoni",
    "worthalter",
    "leuts.eth",
    "guii",
    "troika772",
    "sirvan582",
    "caraquez",
    "mante1809",
    "1firsts",
    "jaruss.eth",
    "manuee",
    "undrgrnd",
    "opensailor",
    "0xmex",
    "ballot",
    "rizkialvaro",
    "konej",
    "85",
    "qusaeri13",
    "cexedey",
    "alexk",
    "ferran",
    "sallyarmbruster.eth",
    "rivaldisy",
    "p4u",
    "vantage",
    "789",
    "do",
    "jodeaw91",
    "imirichika369",
    "raho",
    "lupa",
    "akn",
    "elboletaire.eth",
    "proxystudio.eth",
    "bangdisa",
    "dropthepress",
    "apiskuy1",
    "onvote",
    "fishing",
    "ardansyah",
    "ricecube",
    "lizardkiller",
    "beatle",
    "mongci",
    "excalibur",
    "ameliehua"
  ]
}
```

cc/ @elboletaire 
