### PR TITLE
feature: paginated communities

### DIFF
--- a/mongo/community.go
+++ b/mongo/community.go
@@ -64,7 +64,7 @@ func (ms *MongoStorage) ListFeaturedCommunities(limit, offset int64) ([]Communit
 func (ms *MongoStorage) ListCommunitiesByAdminFID(fid uint64, limit, offset int64) ([]Community, int64, error) {
 	ms.keysLock.RLock()
 	defer ms.keysLock.RUnlock()
-	return ms.listCommunities(bson.M{"owners": fid}, 0, 0)
+	return ms.listCommunities(bson.M{"owners": fid}, limit, offset)
 }
 
 // NextCommunityID returns the next community ID which will be assigned to a new

--- a/mongo/community.go
+++ b/mongo/community.go
@@ -44,85 +44,27 @@ func (ms *MongoStorage) Community(id uint64) (*Community, error) {
 	return ms.community(id)
 }
 
-func (ms *MongoStorage) ListCommunities() ([]Community, error) {
+// ListCommunities returns the list of enabled communities.
+func (ms *MongoStorage) ListCommunities(limit, offset int64) ([]Community, int64, error) {
 	ms.keysLock.RLock()
 	defer ms.keysLock.RUnlock()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cursor, err := ms.communities.Find(ctx, bson.M{"disabled": false})
-	if err != nil {
-		if strings.Contains(err.Error(), "no documents in result") {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var communities []Community
-	ctx, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel2()
-	for cursor.Next(ctx) {
-		var community Community
-		if err := cursor.Decode(&community); err != nil {
-			log.Warn(err)
-			continue
-		}
-		communities = append(communities, community)
-	}
-	return communities, nil
+	// filter by enabled and communities
+	return ms.listCommunities(bson.M{"disabled": false}, limit, offset)
 }
 
 // ListFeaturedCommunities returns the list of featured communities.
-func (ms *MongoStorage) ListFeaturedCommunities() ([]Community, error) {
+func (ms *MongoStorage) ListFeaturedCommunities(limit, offset int64) ([]Community, int64, error) {
 	ms.keysLock.RLock()
 	defer ms.keysLock.RUnlock()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cursor, err := ms.communities.Find(ctx, bson.M{"featured": true})
-	if err != nil {
-		if strings.Contains(err.Error(), "no documents in result") {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var communities []Community
-	ctx, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel2()
-	for cursor.Next(ctx) {
-		var community Community
-		if err := cursor.Decode(&community); err != nil {
-			log.Warn(err)
-			continue
-		}
-		communities = append(communities, community)
-	}
-	return communities, nil
+	return ms.listCommunities(bson.M{"featured": true}, limit, offset)
 }
 
 // ListCommunitiesByAdminFID returns the list of communities where the user is an
 // admin by FID provided.
-func (ms *MongoStorage) ListCommunitiesByAdminFID(fid uint64) ([]Community, error) {
+func (ms *MongoStorage) ListCommunitiesByAdminFID(fid uint64, limit, offset int64) ([]Community, int64, error) {
 	ms.keysLock.RLock()
 	defer ms.keysLock.RUnlock()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cursor, err := ms.communities.Find(ctx, bson.M{"owners": fid})
-	if err != nil {
-		if strings.Contains(err.Error(), "no documents in result") {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var communities []Community
-	ctx, cancel2 := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel2()
-	for cursor.Next(ctx) {
-		var community Community
-		if err := cursor.Decode(&community); err != nil {
-			log.Warn(err)
-			continue
-		}
-		communities = append(communities, community)
-	}
-	return communities, nil
+	return ms.listCommunities(bson.M{"owners": fid}, 0, 0)
 }
 
 // NextCommunityID returns the next community ID which will be assigned to a new
@@ -147,12 +89,12 @@ func (ms *MongoStorage) NextCommunityID() (uint64, error) {
 
 // ListCommunitiesByAdminUsername returns the list of communities where the
 // user is an admin by username provided. It queries about the user FID first.
-func (ms *MongoStorage) ListCommunitiesByAdminUsername(username string) ([]Community, error) {
+func (ms *MongoStorage) ListCommunitiesByAdminUsername(username string, limit, offset int64) ([]Community, int64, error) {
 	user, err := ms.UserByUsername(username)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return ms.ListCommunitiesByAdminFID(user.UserID)
+	return ms.ListCommunitiesByAdminFID(user.UserID, limit, offset)
 }
 
 // DelCommunity removes the community with the specified ID from the database.
@@ -214,6 +156,44 @@ func (ms *MongoStorage) community(id uint64) (*Community, error) {
 		return nil, err
 	}
 	return &community, nil
+}
+
+// listCommunities method returns the list of communities by query. It returns
+// the list of communities, the total number of communities by query, and an
+// error if something goes wrong. It receives the query to filter the
+// communities, the limit of communities to return, and the offset to start
+// returning the communities. It allows to paginate the results of the query.
+func (ms *MongoStorage) listCommunities(query bson.M, limit, offset int64) ([]Community, int64, error) {
+	// count total communities by query
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	total, err := ms.communities.CountDocuments(ctx, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	// get communities with pagination
+	opts := options.Find().SetLimit(limit).SetSkip(offset)
+	ctx, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	cursor, err := ms.communities.Find(ctx, query, opts)
+	if err != nil {
+		if strings.Contains(err.Error(), "no documents in result") {
+			return nil, total, nil
+		}
+		return nil, total, err
+	}
+	var communities []Community
+	ctx, cancel3 := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel3()
+	for cursor.Next(ctx) {
+		var community Community
+		if err := cursor.Decode(&community); err != nil {
+			log.Warn(err)
+			continue
+		}
+		communities = append(communities, community)
+	}
+	return communities, total, nil
 }
 
 // IsCommunityAdmin checks if the user is an admin of the given community by ID.

--- a/types.go
+++ b/types.go
@@ -123,6 +123,14 @@ type Community struct {
 // CommunityList defines the list of communities
 type CommunityList struct {
 	Communities []*Community `json:"communities"`
+	Pagination  *Pagination  `json:"pagination,omitempty"`
+}
+
+// Pagination defines the pagination of a list
+type Pagination struct {
+	Limit  int64 `json:"limit"`
+	Offset int64 `json:"offset"`
+	Total  int64 `json:"total"`
 }
 
 // ElectionVotersUsernames defines the usernames of the voters and the remaining

--- a/webapp/src/components/CensusTypeSelector.tsx
+++ b/webapp/src/components/CensusTypeSelector.tsx
@@ -68,7 +68,7 @@ const CensusTypeSelector = ({ complete, ...props }: FormControlProps & { complet
   })
   const { data: communities, isLoading: cloading } = useQuery({
     queryKey: ['communities', 'byAdmin'],
-    queryFn: () => fetchCommunitiesByAdmin(bfetch, profile!),
+    queryFn: fetchCommunitiesByAdmin(bfetch, profile!, { offset: 0, limit: 20 }),
     enabled: !!profile && !!complete,
   })
 
@@ -132,7 +132,7 @@ const CensusTypeSelector = ({ complete, ...props }: FormControlProps & { complet
               <RSelect
                 placeholder='Choose a community'
                 isLoading={cloading}
-                options={communities?.filter((c) => !c.disabled) || []}
+                options={communities?.communities.filter((c) => !c.disabled) || []}
                 getOptionLabel={(option: Community) => option.name}
                 getOptionValue={(option: Community) => option.id.toString()}
                 components={communitySelector}

--- a/webapp/src/components/Pagination.tsx
+++ b/webapp/src/components/Pagination.tsx
@@ -1,0 +1,54 @@
+import { Button, ButtonGroup } from '@chakra-ui/react'
+import { Dispatch, SetStateAction } from 'react'
+import { FaAngleLeft, FaAngleRight } from 'react-icons/fa6'
+import { paginationItemsPerPage } from '~constants'
+
+export type PaginationProps = {
+  setOffset: Dispatch<SetStateAction<number>>
+  offset: number
+  total: number
+}
+
+export const Pagination = ({ setOffset, offset, total }: PaginationProps) => {
+  const handleNext = () => {
+    setOffset((prevOffset) => prevOffset + paginationItemsPerPage)
+  }
+
+  const handlePrev = () => {
+    setOffset((prevOffset) => Math.max(0, prevOffset - paginationItemsPerPage))
+  }
+
+  const pages = Math.ceil(total / paginationItemsPerPage)
+  const current = offset / paginationItemsPerPage + 1
+
+  if (pages <= 1) return null
+
+  return (
+    <ButtonGroup mt={4} display='flex' justifyContent='end' isAttached>
+      <Button size='sm' onClick={handlePrev} isDisabled={current === 1} leftIcon={<FaAngleLeft />}>
+        Previous
+      </Button>
+      {pages > 1 &&
+        Array.from({ length: pages }, (_, i) => i + 1).map((page) => (
+          <Button
+            key={page}
+            size='sm'
+            onClick={() => setOffset((page - 1) * paginationItemsPerPage)}
+            colorScheme={offset === (page - 1) * paginationItemsPerPage ? 'purple' : undefined}
+            borderRight={page === pages ? 'none' : '1px solid rgba(255, 255, 255, .2)'}
+            isDisabled={page === current}
+          >
+            {page}
+          </Button>
+        ))}
+      <Button
+        size='sm'
+        onClick={handleNext}
+        isDisabled={total < offset + paginationItemsPerPage}
+        rightIcon={<FaAngleRight />}
+      >
+        Next
+      </Button>
+    </ButtonGroup>
+  )
+}

--- a/webapp/src/pages/communities/index.tsx
+++ b/webapp/src/pages/communities/index.tsx
@@ -1,23 +1,33 @@
+import { Box } from '@chakra-ui/react'
 import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 import { useAuth } from '~components/Auth/useAuth'
 import { Check } from '~components/Check'
 import { CommunitiesList } from '~components/Communities'
+import { Pagination } from '~components/Pagination'
 import { fetchCommunities } from '~queries/communities'
 
 const AllCommunitiesList = () => {
   const { bfetch } = useAuth()
+  const [offset, setOffset] = useState<number>(0)
+  const [total, setTotal] = useState<number>(0)
   const { data, error, isLoading } = useQuery({
-    queryKey: ['communities'],
-    queryFn: fetchCommunities(bfetch),
+    queryKey: ['communities', offset],
+    queryFn: fetchCommunities(bfetch, { offset }),
   })
 
-  if (error || isLoading) {
-    return <Check error={error} isLoading={isLoading} />
-  }
+  useEffect(() => {
+    if (!data?.pagination.total) return
+    setTotal(data.pagination.total)
+  }, [data?.pagination.total])
 
-  if (!data) return
-
-  return <CommunitiesList data={data} />
+  return (
+    <Box w='full'>
+      {(error || isLoading) && <Check error={error} isLoading={isLoading} />}
+      <CommunitiesList data={data?.communities || []} />
+      <Pagination total={total} offset={offset} setOffset={setOffset} />
+    </Box>
+  )
 }
 
 export default AllCommunitiesList

--- a/webapp/src/pages/communities/mine.tsx
+++ b/webapp/src/pages/communities/mine.tsx
@@ -1,24 +1,35 @@
+import { Box } from '@chakra-ui/react'
 import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 import { useAuth } from '~components/Auth/useAuth'
 import { Check } from '~components/Check'
 import { CommunitiesList } from '~components/Communities'
+import { Pagination } from '~components/Pagination'
 import { fetchCommunitiesByAdmin } from '~queries/communities'
 
 const MyCommunitiesList = () => {
   const { bfetch, profile } = useAuth()
+  const [offset, setOffset] = useState<number>(0)
+  const [total, setTotal] = useState<number>(0)
+
   const { data, error, isLoading } = useQuery({
-    queryKey: ['communities', 'byAdmin'],
-    queryFn: () => fetchCommunitiesByAdmin(bfetch, profile!),
+    queryKey: ['communities', 'byAdmin', profile?.fid, offset],
+    queryFn: fetchCommunitiesByAdmin(bfetch, profile!, { offset }),
     enabled: profile != null,
   })
 
-  if (error || isLoading) {
-    return <Check error={error} isLoading={isLoading} />
-  }
+  useEffect(() => {
+    if (!data?.pagination.total) return
+    setTotal(data.pagination.total)
+  }, [data?.pagination.total])
 
-  if (!data) return
-
-  return <CommunitiesList data={data} />
+  return (
+    <Box w='full'>
+      {(error || isLoading) && <Check error={error} isLoading={isLoading} />}
+      <CommunitiesList data={data?.communities || []} />
+      <Pagination total={total} offset={offset} setOffset={setOffset} />
+    </Box>
+  )
 }
 
 export default MyCommunitiesList

--- a/webapp/src/queries/communities.ts
+++ b/webapp/src/queries/communities.ts
@@ -1,18 +1,22 @@
-import { appUrl } from '~constants'
+import { appUrl, paginationItemsPerPage } from '~constants'
 
-export const fetchCommunities = (bfetch: FetchFunction) => async () => {
-  const response = await bfetch(`${appUrl}/communities`)
-  const { communities } = (await response.json()) as { communities: Community[] }
+export const fetchCommunities =
+  (bfetch: FetchFunction, { limit = paginationItemsPerPage, offset = 0 }) =>
+  async () => {
+    const response = await bfetch(`${appUrl}/communities?limit=${limit}&offset=${offset}`)
+    const { communities, pagination } = (await response.json()) as { communities: Community[]; pagination: Pagination }
 
-  return communities
-}
+    return { communities, pagination }
+  }
 
-export const fetchCommunitiesByAdmin = async (bfetch: FetchFunction, profile: Profile) => {
-  const response = await bfetch(`${appUrl}/communities?byAdminFID=${profile.fid}`)
-  const { communities } = (await response.json()) as { communities: Community[] }
+export const fetchCommunitiesByAdmin =
+  (bfetch: FetchFunction, profile: Profile, { limit = paginationItemsPerPage, offset = 0 }) =>
+  async () => {
+    const response = await bfetch(`${appUrl}/communities?byAdminFID=${profile.fid}&limit=${limit}&offset=${offset}`)
+    const { communities, pagination } = (await response.json()) as { communities: Community[]; pagination: Pagination }
 
-  return communities
-}
+    return { communities, pagination }
+  }
 
 export const fetchCommunity = (bfetch: FetchFunction, id: string) => async () => {
   const response = await bfetch(`${appUrl}/communities/${id}`)

--- a/webapp/src/util/constants.ts
+++ b/webapp/src/util/constants.ts
@@ -7,3 +7,5 @@ export const degenContractAddress = import.meta.env.VOCDONI_COMMUNITYHUBADDRESS
 export const vocdoniEnvironment = import.meta.env.VOCDONI_ENVIRONMENT
 
 export const vocdoniExplorer = import.meta.env.VOCDONI_EXPLORER
+
+export const paginationItemsPerPage = 12

--- a/webapp/types.d.ts
+++ b/webapp/types.d.ts
@@ -21,6 +21,12 @@ declare global {
     url: string
   }
 
+  type Pagination = {
+    limit: number
+    offset: number
+    total: number
+  }
+
   type Profile = {
     fid: number
     username: string


### PR DESCRIPTION
Now the `GET /communities` endpoint also supports two new query parameters:
 - `limit`: the maximum number of results to return (by default 100).
 - `offset`: the start number of items to return results (by default 0).

It response now returns:
```json
{
  "communities": [...],
  "pagination": {
    "limit": 5,
    "offset": 0,
    "total": 9
  }
}
```